### PR TITLE
Use cURL extension instead of Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.3",
-        "guzzle/guzzle": ">=3.0",
+        "ext-curl": "*",
         "satooshi/php-coveralls": "dev-master",
         "symfony/console": ">=2.0"
     },

--- a/src/CodeClimate/Bundle/TestReporterBundle/Command/TestReporterCommand.php
+++ b/src/CodeClimate/Bundle/TestReporterBundle/Command/TestReporterCommand.php
@@ -54,26 +54,21 @@ class TestReporterCommand extends Command
         } else {
             $client = new ApiClient();
             $response = $client->send($json);
+            switch ($response->code) {
+                case 200:
+                    $output->writeln("Test coverage data sent.");
+                    break;
 
-            if ($response) {
-                $code = $response->getStatusCode();
+                case 401:
+                    $output->writeln("Invalid CODECLIMATE_REPO_TOKEN.");
+                    $ret = 1;
+                    break;
 
-                switch ($code) {
-                    case 200:
-                        $output->writeln("Test coverage data sent");
-                        break;
-                    case 401:
-                        $output->writeln("An invalid CODECLIMATE_REPO_TOKEN repo token was specified.");
-                        $ret = 1;
-                        break;
-                    default:
-                        $output->writeln("Status code: ".$code);
-                        $ret = 1;
-                        break;
-                }
-            } else {
-                $output->writeln("Unknown error posting Test coverage data.");
-                $ret = 1;
+                default:
+                    $output->writeln("Unexpected response: ".$response->code." ".$response->message);
+                    $output->writeln($response->body);
+                    $ret = 1;
+                    break;
             }
         }
 


### PR DESCRIPTION
The only HTTP client operation in this library is to transfer the resulting JSON data in a trivial HTTP POST request with minimal error handling (can't do anything besides outputting the error to CLI).

This PR…
1. Replaces the dependency on Guzzle with a dependency on the PHP cURL extension.
2. Changes `ApiClient` to return a very simplistic response object.
3. Adjusts `TestReporterCommand` accordingly.

---

_Note: An alternative implementation using PHP HTTP/SSL stream contexts would be possible, but requires additional code to cleanly handle PHP warnings possibly thrown by `fopen()`, unless error handling is removed altogether._
