### PR TITLE
Added branch alias for v0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,5 +29,9 @@
         }
     },
     "bin": ["composer/bin/test-reporter"],
-    "extra": { }
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.1.x-dev"
+       }
+    }
 }


### PR DESCRIPTION
This will allow to install dev-master after releases have been made.

I've also changed requirement so that stable version higher that 0.6.1 of `satooshi/php-coveralls` is used, this will avoid issues where `"minimum-stability": "dev"` will be required.
