### PR TITLE
Fix: Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,30 @@
 language: php
+
+sudo: false
+
 php:
   - 5.5
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 env:
   global:
     secure: Yc+Xohkr/iEUU7FCQuSLXAE9ywNW9g6CfrM1Ki0Hl+fS15F3AXT7dFY8EyCJ4dP1/oI0dBmwrGWrltXV0XWIjGV1Ms3tefCgQpBBAqwT+hImzVP3RbpZW8Iyo2d0VgiDemQF1LWYD/pKu6d8WljTnv5D77NIMdEJjQ0uzeTLWdw=
-install: composer install --dev
+
+before_install:
+  - composer self-update
+
+install:
+  - composer install --prefer-dist
+
 before_script:
   - git config --global user.email "travis-ci@codeclimate.com"
   - git config --global user.name "Travis CI"
+
+script:
+  - vendor/bin/phpunit
+
 after_script:
   - php composer/bin/test-reporter


### PR DESCRIPTION
This PR

* [x] adds some vertical whitespace to `.travis.yml` for enhanced legibility
* [x] updates composer itself in the `before_install` section
* [x] removes the `--dev` flag as development dependencies are installed by default
* [x] explicitly sends builds to container-based infrastructure
* [x] enables caching of dependencies between builds
* [x] uses `phpunit` as installed with dependencies 

Somewhat related to https://github.com/codeclimate/php-test-reporter/pull/30.