### PR TITLE
Updating 'satooshi/php-coveralls' to use version 1.0.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3",
         "ext-curl": "*",
-        "satooshi/php-coveralls": "0.6.*",
+        "satooshi/php-coveralls": "1.0.*",
         "symfony/console": ">=2.0"
     },
     "require-dev": {

--- a/src/CodeClimate/Bundle/TestReporterBundle/CoverageCollector.php
+++ b/src/CodeClimate/Bundle/TestReporterBundle/CoverageCollector.php
@@ -3,8 +3,8 @@ namespace CodeClimate\Bundle\TestReporterBundle;
 
 use CodeClimate\Component\System\Git\GitCommand;
 use CodeClimate\Bundle\TestReporterBundle\Entity\JsonFile;
-use Contrib\Bundle\CoverallsV1Bundle\Api\Jobs;
-use Contrib\Bundle\CoverallsV1Bundle\Config\Configuration;
+use Satooshi\Bundle\CoverallsV1Bundle\Api\Jobs;
+use Satooshi\Bundle\CoverallsV1Bundle\Config\Configuration;
 
 class CoverageCollector
 {
@@ -20,7 +20,7 @@ class CoverageCollector
     {
         $rootDir = getcwd();
         $config = new Configuration();
-        $config->setSrcDir($rootDir);
+        $config->setRootDir($rootDir);
         $this->setCloverPaths($paths);
         foreach ($this->getCloverPaths() as $path) {
             if (file_exists($path)) {

--- a/src/CodeClimate/Bundle/TestReporterBundle/Entity/JsonFile.php
+++ b/src/CodeClimate/Bundle/TestReporterBundle/Entity/JsonFile.php
@@ -4,7 +4,7 @@ namespace CodeClimate\Bundle\TestReporterBundle\Entity;
 use CodeClimate\Component\System\Git\GitCommand;
 use CodeClimate\Bundle\TestReporterBundle\Entity\CiInfo;
 use CodeClimate\Bundle\TestReporterBundle\Version;
-use Contrib\Bundle\CoverallsV1Bundle\Entity\JsonFile as SatooshiJsonFile;
+use Satooshi\Bundle\CoverallsV1Bundle\Entity\JsonFile as SatooshiJsonFile;
 
 class JsonFile extends SatooshiJsonFile
 {

--- a/src/CodeClimate/Component/System/Git/GitCommand.php
+++ b/src/CodeClimate/Component/System/Git/GitCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace CodeClimate\Component\System\Git;
 
-use Contrib\Component\System\SystemCommand;
+use Satooshi\Component\System\SystemCommand;
 
 class GitCommand extends SystemCommand
 {


### PR DESCRIPTION
Updating [satooshi/php-coveralls](https://github.com/satooshi/php-coveralls) to version `1.0.*`. 

This involves: 
- Changing reference from `Contrib\\` to new namespace `Satooshi\\`. (issue: `https://github.com/satooshi/php-coveralls/issues/38`)
- Changing `setSrcDir` to `setRootDir` method on `Configuration` class since `setSrcDir` has been removed. (issue `https://github.com/satooshi/php-coveralls/issues/126`)

Original PR: https://github.com/codeclimate/php-test-reporter/pull/44

Branch name better describes purpose of PR.