### PR TITLE
support for building a .phar command line utility from project sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build/
 vendor/
+box.phar
 composer.lock
 composer.phar
+test-reporter.phar

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 build/
 vendor/
 box.phar
+codeclimate-test-reporter.phar
 composer.lock
 composer.phar
-test-reporter.phar

--- a/box.json
+++ b/box.json
@@ -1,0 +1,23 @@
+{
+  "alias": "test-reporter.phar",
+  "chmod": "0755",
+  "directories": ["src"],
+  "compactors": [
+    "Herrera\\Box\\Compactor\\Php"
+  ],
+  "extract": true,
+  "files": [
+    "LICENSE"
+  ],
+  "finder": [
+    {
+      "name": ["*.php", "*.pem"],
+      "exclude": ["tests"],
+      "in": ["vendor"]
+    }
+  ],
+  "git-version": "package_version",
+  "main": "composer/bin/test-reporter",
+  "output": "test-reporter.phar",
+  "stub": true
+}

--- a/box.json
+++ b/box.json
@@ -1,5 +1,5 @@
 {
-  "alias": "test-reporter.phar",
+  "alias": "codeclimate-test-reporter.phar",
   "chmod": "0755",
   "directories": ["src"],
   "compactors": [
@@ -18,6 +18,6 @@
   ],
   "git-version": "package_version",
   "main": "composer/bin/test-reporter",
-  "output": "test-reporter.phar",
+  "output": "codeclimate-test-reporter.phar",
   "stub": true
 }


### PR DESCRIPTION
Utility tools similar to codeclimate/php-test-reporter can usually be downloaded and used as a standalone .phar package. These binaries can be useful because importing the tool into your project's composer.json might unnecessarily restrict which dependencies you can use (see issue #31), plus there's the side benefit of taking pressure off Composer's package resolving process when you do a ```composer update```.

With that in mind I've ported the satooshi/php-coveralls [box.json](https://github.com/satooshi/php-coveralls/blob/master/box.json) file into the project. These are the steps to produce one such phar:
```sh
$ cd php-test-reporter
$ curl -LSs https://box-project.github.io/box2/installer.php | php
$ composer install --no-dev
$ ./box.phar build
```

And [here](https://github.com/1ma/Psr7Hmac/blob/156e6ddc71186d24063779b38895aa8aec83403e/.travis.yml#L18) is an example of how it might be used in a .travis.yml file.


If you were to accept this PR maybe you could distribute from now on a .phar file in the Releases page, just as Satooshi [does](https://github.com/satooshi/php-coveralls/releases/tag/v1.0.1) with php-coveralls.

So, there's that. Have a nice day :)