### PR TITLE
Updated symfony/console to require v2 or v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3",
         "ext-curl": "*",
         "satooshi/php-coveralls": "^1.0",
-        "symfony/console": "^2.0"
+        "symfony/console": "^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*@stable",


### PR DESCRIPTION
Previously, only symfony/console v2 was supported, causing some
collision with projects that use v3

This small edit makes it use either v2 or v3. Using v3 if symfony/console is not being used yet.

It's a small change, and doesn't really cause any harm as the features of Console that are used are equal in both v2 and v3.