### PR TITLE
Fix: Use stripos() instead of preg_match()

### DIFF
--- a/src/TestReporter/Entity/CiInfo.php
+++ b/src/TestReporter/Entity/CiInfo.php
@@ -25,7 +25,7 @@ class CiInfo
             return $this->tddiumProperties();
         }
 
-        if (isset($_SERVER["CI_NAME"]) && preg_match('/codeship/i', $_SERVER["CI_NAME"])) {
+        if (isset($_SERVER["CI_NAME"]) && false !== stripos($_SERVER["CI_NAME"], 'codeship')) {
             return $this->codeshipProperties();
         }
 


### PR DESCRIPTION
This PR

* [x] uses `stripos()` instead of `preg_match()`

💁‍♂️ See http://php.net/manual/en/function.preg-match.php#refsect1-function.preg-match-notes:

>**Tip**
>Do not use `preg_match()` if you only want to check if one string is contained in another string. Use `strpos()` instead as it will be faster.