### PR TITLE
Fix: Remove unnecessary docblocks

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -13,19 +13,11 @@ class Application extends BaseApplication
 {
     // internal method
 
-    /**
-     * {@inheritdoc}
-     * @see \Symfony\Component\Console\Application::getCommandName()
-     */
     protected function getCommandName(InputInterface $input)
     {
         return 'upload';
     }
 
-    /**
-     * {@inheritdoc}
-     * @see \Symfony\Component\Console\Application::getDefaultCommands()
-     */
     protected function getDefaultCommands()
     {
         // Keep the core default commands to have the HelpCommand
@@ -49,10 +41,6 @@ class Application extends BaseApplication
 
     // accessor
 
-    /**
-     * {@inheritdoc}
-     * @see \Symfony\Component\Console\Application::getDefinition()
-     */
     public function getDefinition()
     {
         $inputDefinition = parent::getDefinition();

--- a/src/ConsoleCommands/RollbackCommand.php
+++ b/src/ConsoleCommands/RollbackCommand.php
@@ -24,12 +24,6 @@ class RollbackCommand extends Command
         $this->setDescription('Rolls back this PHAR to the previous version.');
     }
 
-    /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     *
-     * @return int
-     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $input->validate();

--- a/src/ConsoleCommands/SelfUpdateCommand.php
+++ b/src/ConsoleCommands/SelfUpdateCommand.php
@@ -40,12 +40,6 @@ class SelfUpdateCommand extends Command
         );
     }
 
-    /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     *
-     * @return int
-     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $logger  = new ConsoleLogger($output);

--- a/src/ConsoleCommands/UploadCommand.php
+++ b/src/ConsoleCommands/UploadCommand.php
@@ -14,10 +14,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class UploadCommand extends Command
 {
-    /**
-     * {@inheritdoc}
-     * @see \Symfony\Component\Console\Command\Command::configure()
-     */
     protected function configure()
     {
         $this
@@ -37,10 +33,6 @@ class UploadCommand extends Command
             );
     }
 
-    /**
-     * {@inheritdoc}
-     * @see \Symfony\Component\Console\Command\Command::execute()
-     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $ret       = 0;


### PR DESCRIPTION
This PR

* [x] removes unnecessary docblocks

💁‍♂️ As docblocks are automatically inherited from methods either existing in a parent class or an implemented interface, these docblocks do not add any value.